### PR TITLE
Setter for freqofs

### DIFF
--- a/src/scip/heur.c
+++ b/src/scip/heur.c
@@ -1553,6 +1553,17 @@ int SCIPheurGetFreqofs(
    return heur->freqofs;
 }
 
+/** sets frequency offset of primal heuristic */
+void SCIPheurSetFreqofs(
+   SCIP_HEUR*            heur,               /**< primal heuristic */
+   int                   freqofs             /**< new frequency offset of heuristic */
+   )
+{
+   assert(heur != NULL);
+
+   heur->freqofs = freqofs;
+}
+
 /** gets maximal depth level for calling primal heuristic (returns -1, if no depth limit exists) */
 int SCIPheurGetMaxdepth(
    SCIP_HEUR*            heur                /**< primal heuristic */

--- a/src/scip/pub_heur.h
+++ b/src/scip/pub_heur.h
@@ -131,6 +131,13 @@ int SCIPheurGetFreqofs(
    SCIP_HEUR*            heur                /**< primal heuristic */
    );
 
+/** sets frequency offset of primal heuristic */
+SCIP_EXPORT
+void SCIPheurSetFreqofs(
+   SCIP_HEUR*            heur,               /**< primal heuristic */
+   int                   freqofs             /**< new frequency offset of heuristic */
+   );
+
 /** gets maximal depth level for calling primal heuristic (returns -1, if no depth limit exists) */
 SCIP_EXPORT
 int SCIPheurGetMaxdepth(


### PR DESCRIPTION
Merry Christmas,
I am looking into SCIP for a research project and was wondering whether there is a specific reason why certain heuristic parameters are only exposed by getter methods in the public API. This PR includes an example. 
The option of setting consistent heuristic parameters would be useful for me (like implemented with SCIPheurSetFreq).
Best regards,
Anton Hinneck