### PR TITLE
Create public Docker image for SCIPOptSuite

### DIFF
--- a/.github/workflows/build_and_push_docker.yml
+++ b/.github/workflows/build_and_push_docker.yml
@@ -1,4 +1,4 @@
-name: Build And Release Docker Image
+name: Build And Push Docker Image
 
 on:
   workflow_dispatch:
@@ -9,8 +9,8 @@ on:
         type: number
 
 env:
-  IMAGE_NAME: testing #scipoptsuite
-  REPOSITORY_NAME: blevkovych #scipoptsuite
+  IMAGE_NAME: scipoptsuite
+  REPOSITORY_NAME: scipoptsuite
 
 jobs:
   build:
@@ -35,7 +35,7 @@ jobs:
       id: metadata
       uses: docker/metadata-action@v5
       with:
-        images: $REPOSITORY_NAME/$IMAGE_NAME
+        images: ${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}
         tags: |
           type=raw,value=latest
           type=raw,value=${{ github.event.inputs.version }}

--- a/.github/workflows/build_and_release_docker.yml
+++ b/.github/workflows/build_and_release_docker.yml
@@ -1,0 +1,50 @@
+name: Build And Release Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version of SCIPOptSuite like #.#.#'
+        required: true
+        type: number
+
+env:
+  IMAGE_NAME: testing #scipoptsuite
+  REPOSITORY_NAME: blevkovych #scipoptsuite
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Set Docker Tags
+      id: metadata
+      uses: docker/metadata-action@v5
+      with:
+        images: $REPOSITORY_NAME/$IMAGE_NAME
+        tags: |
+          type=raw,value=latest
+          type=raw,value=${{ github.event.inputs.version }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.metadata.outputs.tags }}
+        build-args: TAG=${{ github.event.inputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:bullseye-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETPLATFORM
+ARG TAG=8.0.4
+
+RUN apt-get update && apt-get -y install \
+    build-essential \
+    libcliquer1 \
+    gfortran \
+    liblapack3 \
+    libopenblas-dev \
+    libgsl25 \
+    libtbb2 \
+    curl
+
+WORKDIR /tmp
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then curl -Lo SCIPOptSuite.deb https://github.com/scipopt/scip/releases/download/$(echo "v${TAG}" | tr -d '.')/SCIPOptSuite-${TAG}-Linux-debian.deb; fi
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then curl -Lo SCIPOptSuite.deb https://github.com/scipopt/scip/releases/download/$(echo "v${TAG}" | tr -d '.')/SCIPOptSuite-${TAG}-Linux-arm64.deb; fi
+RUN dpkg -i SCIPOptSuite.deb && rm SCIPOptSuite.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bullseye-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETPLATFORM
-ARG TAG=8.0.4
+ARG TAG
 
 RUN apt-get update && apt-get -y install \
     build-essential \


### PR DESCRIPTION
@mmghannam this is the dockerfile to build linux/arm64 and linux/amd64 images and workflow to push them to dockerhub, please add `secrets.DOCKERHUB_USERNAME`, `secrets.DOCKERHUB_TOKEN` to repository secrets. Also I assume [this](https://hub.docker.com/r/scipoptsuite/scipoptsuite) is your dockerhub account if not change `IMAGE_NAME`, `REPOSITORY_NAME`.

Works with version `8.0.4`