### PR TITLE
Add gap synchronization check to stop concurrent solvers

### DIFF
--- a/src/scip/concsolver.c
+++ b/src/scip/concsolver.c
@@ -332,7 +332,6 @@ SCIP_RETCODE SCIPconcsolverExec(
 
    /* set the stopped flag to false */
    concsolver->stopped = FALSE;
-
    /* then call the execute callback */
    SCIP_CALL( concsolver->type->concsolverexec(concsolver, &concsolver->solvingtime, &concsolver->nlpiterations, &concsolver->nnodes) );
 

--- a/src/scip/concsolver.c
+++ b/src/scip/concsolver.c
@@ -500,7 +500,7 @@ SCIP_RETCODE SCIPconcsolverSync(
       SCIPdebugMessage("syncfreq after reading the next syncdata is %g\n", concsolver->syncfreq);
       syncdata = SCIPsyncstoreGetNextSyncdata(syncstore, concsolver->syncdata, concsolver->syncfreq, concsolver->nsyncs, &concsolver->syncdelay);
    }
-
+   SCIPsyncstoreCheckGapAndStop(syncstore,set->limit_gap);
    SCIP_CALL( SCIPstopClock(set->scip, concsolver->totalsynctime) );
 
    return SCIP_OKAY;

--- a/src/scip/concsolver_scip.c
+++ b/src/scip/concsolver_scip.c
@@ -561,7 +561,7 @@ SCIP_DECL_CONCSOLVEREXEC(concsolverScipExec)
 
    data = SCIPconcsolverGetData(concsolver);
    assert(data != NULL);
-
+   
    /* print info message that solving has started */
    SCIPinfoMessage(data->solverscip, NULL, "starting solve in concurrent solver '%s'\n", SCIPconcsolverGetName(concsolver));
 

--- a/src/scip/concurrent.c
+++ b/src/scip/concurrent.c
@@ -476,7 +476,6 @@ SCIP_RETCODE execConcsolver(
 
    SCIP_CALL( SCIPconcsolverExec(scip->set->concsolvers[SCIPtpiGetThreadNum()]) );
    SCIP_CALL( SCIPconcsolverSync(scip->set->concsolvers[SCIPtpiGetThreadNum()], scip->set) );
-
    return SCIP_OKAY;
 }
 

--- a/src/scip/syncstore.c
+++ b/src/scip/syncstore.c
@@ -235,6 +235,18 @@ SCIP_RETCODE SCIPsyncstoreExit(
    return SCIP_OKAY;
 }
 
+/** Checks the current concurrent gap against a specified limit gap and stops the synchronization store if the gap is smaller.*/
+void SCIPsyncstoreCheckGapAndStop(
+   SCIP_SYNCSTORE*       syncstore,           /**< the synchronization store */
+   double                limit_gap
+   )
+{
+   double gap;
+   gap = SCIPgetConcurrentGap(syncstore->mainscip);
+   if(gap < limit_gap)
+      syncstore->stopped = TRUE;
+}
+
 /** checks whether the solve-is-stopped flag in the syncstore has been set by any thread */
 SCIP_Bool SCIPsyncstoreSolveIsStopped(
    SCIP_SYNCSTORE*       syncstore           /**< the synchronization store */

--- a/src/scip/syncstore.c
+++ b/src/scip/syncstore.c
@@ -235,16 +235,19 @@ SCIP_RETCODE SCIPsyncstoreExit(
    return SCIP_OKAY;
 }
 
-/** Checks the current concurrent gap against a specified limit gap and stops the synchronization store if the gap is smaller.*/
+/** Checks the current concurrent gap against a specified limit gap and stops concsolvers if the gap is smaller.*/
 void SCIPsyncstoreCheckGapAndStop(
-   SCIP_SYNCSTORE*       syncstore,           /**< the synchronization store */
-   double                limit_gap
+   SCIP_SYNCSTORE*       syncstore,          /**< the synchronization store */
+   SCIP_Real             limit_gap           /**< limit_gap in global setting */               
    )
 {
-   double gap;
+   SCIP_Real gap;
+
    gap = SCIPgetConcurrentGap(syncstore->mainscip);
-   if(gap < limit_gap)
+
+   if( gap < limit_gap )
       syncstore->stopped = TRUE;
+
 }
 
 /** checks whether the solve-is-stopped flag in the syncstore has been set by any thread */

--- a/src/scip/syncstore.h
+++ b/src/scip/syncstore.h
@@ -69,6 +69,12 @@ SCIP_RETCODE SCIPsyncstoreExit(
    SCIP_SYNCSTORE*       syncstore           /**< the synchronization store */
    );
 
+/** Checks the current concurrent gap against a specified limit gap and stops the synchronization store if the gap is smaller.*/
+void SCIPsyncstoreCheckGapAndStop(
+   SCIP_SYNCSTORE*       syncstore,           /**< the synchronization store */
+   double                limit_gap
+   );
+
 /** checks whether the solve-is-stopped flag in the syncstore has been set by any thread */
 SCIP_EXPORT
 SCIP_Bool SCIPsyncstoreSolveIsStopped(


### PR DESCRIPTION
This commit introduces a mechanism to enhance the synchronization process of the SYNCSTORE among concurrent solvers. It checks if the latest gap in the SYNCSTORE meets the predefined limit_gap. If the condition is satisfied, the commit stops updating the shared cache and terminates all ongoing concurrent solver processes.

The changes include:
- A new function  in syncstore.c that compares the current concurrent gap with the limit_gap and sets the syncstore's stopped flag accordingly.
- Integration of this check within the synchronization logic to ensure timely termination of solvers when the gap criterion is met.

This improvement aims to optimize resource utilization by preventing unnecessary computations once the desired gap threshold is achieved.