### PR TITLE
Add missing return statements in doxygen docu of scip_solvingstats

### DIFF
--- a/src/scip/scip_solvingstats.h
+++ b/src/scip/scip_solvingstats.h
@@ -1003,7 +1003,10 @@ int SCIPgetNEnabledConss(
    SCIP*                 scip                /**< SCIP data structure */
    );
 
-/** gets average dual bound of all unprocessed nodes for original problem */
+/** gets average dual bound of all unprocessed nodes for original problem
+ *
+ * @return the average dual bound of all unprocessed nodes for original problem
+ */
 SCIP_EXPORT
 SCIP_Real SCIPgetAvgDualbound(
    SCIP*                 scip                /**< SCIP data structure */
@@ -1130,7 +1133,10 @@ SCIP_Real SCIPgetFirstLPLowerboundRoot(
    );
 
 
-/** the primal bound of the very first solution */
+/** gets the primal bound of the very first solution
+ *
+ * @return the primal bound of the very first solution
+ */
 SCIP_EXPORT
 SCIP_Real SCIPgetFirstPrimalBound(
    SCIP*                 scip                /**< SCIP data structure */
@@ -1474,7 +1480,10 @@ SCIP_Real SCIPgetAvgPseudocostScoreCurrentRun(
    SCIP*                 scip                /**< SCIP data structure */
    );
 
-/** gets the average conflict score value over all variables */
+/** gets the average conflict score value over all variables
+ *
+ * @return the average conflict score value over all variables
+ */
 SCIP_EXPORT
 SCIP_Real SCIPgetAvgConflictScore(
    SCIP*                 scip                /**< SCIP data structure */
@@ -2257,7 +2266,10 @@ void SCIPstoreSolutionGap(
    SCIP*                 scip                /**< SCIP data structure */
    );
 
-/** recomputes and returns the primal dual gap stored in the stats */
+/** recomputes and returns the primal dual gap stored in the stats
+ *
+ * @return returns the primal dual gap stored in the stats
+ */
 SCIP_EXPORT
 SCIP_Real SCIPgetPrimalDualIntegral(
    SCIP*                 scip                /**< SCIP data structure */


### PR DESCRIPTION
Within SCIP++ I use a Python script to extract all solving statistics https://github.com/scipopt/SCIPpp/blob/main/utils/extract_solvingstats.py

I added some "missing" `@return` statements to the documentation so that I can extract the info automatically