### PR TITLE
Fix max matrix size in SCIPexprComputeQuadraticCurvature

### DIFF
--- a/src/scip/expr.c
+++ b/src/scip/expr.c
@@ -3681,10 +3681,10 @@ SCIP_RETCODE SCIPexprComputeQuadraticCurvature(
    n  = quaddata->nquadexprs;
 
    /* do not check curvature if nn will be too large
-    * we want nn * sizeof(real) to fit into an unsigned int, so n must be <= sqrt(unit_max/sizeof(real))
-    * sqrt(2*214748364/8) = 7327.1475350234
+    * we want nn * sizeof(real) to fit into an unsigned int, so n must be <= sqrt(uint_max/sizeof(real))
+    * sqrt(4294967295/8) = 23170.47500322339
     */
-   if( n > 7000 )
+   if( n > 23000 )
    {
       SCIPmessageFPrintVerbInfo(messagehdlr, set->disp_verblevel, SCIP_VERBLEVEL_FULL, NULL,
             "number of quadratic variables is too large (%d) to check the curvature\n", n);

--- a/src/scip/nlhdlr_soc.c
+++ b/src/scip/nlhdlr_soc.c
@@ -2148,7 +2148,7 @@ SCIP_RETCODE detectSocQuadraticComplex(
    }
 
    /* check that nvars*nvars doesn't get too large, see also SCIPcomputeExprQuadraticCurvature() */
-   if( nvars > 7000 )
+   if( nvars > 23000 )
    {
       SCIPverbMessage(scip, SCIP_VERBLEVEL_FULL, NULL, "nlhdlr_soc - number of quadratic variables is too large (%d) to check the curvature\n", nvars);
       SCIPfreeBufferArray(scip, &occurringexprs);


### PR DESCRIPTION
Problem that in comment and in calculation number `214748364` was used as `INT_MAX`, but `INT_MAX` is equal to `2^31 - 1 = 2147483647`, so last digit was missed