### PR TITLE
fix segfault in cons_nonlinear createCons

### DIFF
--- a/src/scip/cons_nonlinear.c
+++ b/src/scip/cons_nonlinear.c
@@ -1361,7 +1361,7 @@ SCIP_RETCODE createCons(
    conshdlrdata = SCIPconshdlrGetData(conshdlr);
    assert(conshdlrdata != NULL);
 
-   if( local && SCIPgetDepth(scip) != 0 )
+   if( local && scip->tree != NULL && SCIPgetDepth(scip) != 0 )
    {
       SCIPerrorMessage("Locally valid nonlinear constraints are not supported, yet.\n");
       return SCIP_INVALIDCALL;


### PR DESCRIPTION
src/scip/cons_nonlinear.c (createCons): Check that scip->tree != NULL before calling SCIPgetDepth(scip). Otherwise, if this method gets called with local = TRUE, it will segfault in SCIPgetDepth, which attempts to dereference a NULL tree.

This method ends up getting called with local = TRUE when the user (legitimately or not) attempts to build a disjunction of nonlinear constraints. Then heuristics such as RENS will try to create a local nonlinear constraint from that disjunction of nonlinear constraints. At that point, createCons gets called on a scip which has no tree yet, and a segfault ensues. Even if that input is not supported, it should not segfault SCIP with a null pointer dereference.

But I generally have to ask whether that "Locally valid nonlinear constraints are not supported, yet." check is even needed at all. Why are they not supported? What needs to be done for them to be supported? Even with this fix for the segfault, the sub-SCIP ends up failing with that "Locally valid nonlinear constraints are not supported, yet." error (at a later stage where the tree is not NULL anymore), so the heuristics needing such a sub-SCIP cannot be used. Just changing the whole if to if( 0 ) appears to make it work for me, but I am not familiar enough with the internals of SCIP to check that the resulting computations are valid.