### PR TITLE
fix cons_nonlinear consssorted flag for variables

### DIFF
--- a/src/scip/cons_nonlinear.c
+++ b/src/scip/cons_nonlinear.c
@@ -1128,7 +1128,7 @@ SCIP_RETCODE catchVarEvent(
    if( ownerdata->nconss <= 1 )
       ownerdata->consssorted = TRUE;
    else if( ownerdata->consssorted )
-      ownerdata->consssorted = compIndexConsNonlinear(ownerdata->conss[ownerdata->nconss-2], ownerdata->conss[ownerdata->nconss-1]) > 0;
+      ownerdata->consssorted = compIndexConsNonlinear(ownerdata->conss[ownerdata->nconss-2], ownerdata->conss[ownerdata->nconss-1]) < 0;
 
    /* catch variable events, if not done so yet (first constraint) */
    if( ownerdata->filterpos < 0 )


### PR DESCRIPTION
src/scip/cons_nonlinear.c (catchVarEvent): Fix inverted logic when setting ownerdata->consssorted for a variable. This resulted in the array incorrectly being marked as sorted when it was actually reverse-sorted, and as a result, the lookup with SCIPsortedvecFindPtr in dropVarEvent failing with:
[cons_nonlinear.c:1250] ERROR: Constraint <...> not in constraint array of expression for variable <...>
Thankfully, the fix is trivial.