### PR TITLE
Fix nlhdlr_soc assertion failure

### DIFF
--- a/src/scip/nlhdlr_soc.c
+++ b/src/scip/nlhdlr_soc.c
@@ -1326,11 +1326,10 @@ SCIP_RETCODE detectSocNorm(
    *success = FALSE;
    issoc = TRUE;
 
-   /* relation is not "<=" -> skip */
-   if( SCIPgetExprNLocksPosNonlinear(expr) == 0 )
+   /* relation is not "<=" or expression is a leaf -> skip */
+   if( SCIPgetExprNLocksPosNonlinear(expr) == 0
+      || SCIPexprGetNChildren(expr) == 0 )
       return SCIP_OKAY;
-
-   assert(SCIPexprGetNChildren(expr) > 0);
 
    child = SCIPexprGetChildren(expr)[0];
    assert(child != NULL);


### PR DESCRIPTION
src/scip/nlhdlr_soc.c (detectSocNorm): It is valid for an expression to have no children, e.g., a variable or constant expression. Such an expression does not form a norm, so make the function simply return early without crashing with an assertion failure.