### PR TITLE
WIP/RFC: Do not call SCIPincludeObjExprhdlr in exprCopyhdlrObj

### DIFF
--- a/src/objscip/objexprhdlr.cpp
+++ b/src/objscip/objexprhdlr.cpp
@@ -76,7 +76,7 @@ SCIP_DECL_EXPRCOPYHDLR(exprCopyhdlrObj)
       newobjexprhdlr = dynamic_cast<scip::ObjExprhdlr*> (exprhdlrdata->objexprhdlr->clone(scip));
 
       /* call include method of expression handler object */
-      SCIP_CALL( SCIPincludeObjExprhdlr(scip, newobjexprhdlr, TRUE) );
+      //SCIP_CALL( SCIPincludeObjExprhdlr(scip, newobjexprhdlr, TRUE) );
    }
 
    return SCIP_OKAY;


### PR DESCRIPTION
src/objscip/objexprhdlr.cpp (exprCopyhdlrObj): Comment out the call to SCIPincludeObjExprhdlr because this is called from the Java code.

See https://github.com/scipopt/scip/pull/149#issuecomment-2986486164 for details.

TODO: This is a quick hack to fix the double free. Find a solution that is acceptable upstream and gets applied consistently also to constraint handlers etc.