### PR TITLE
check: fix invalid ctest invocation

### DIFF
--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -4,7 +4,7 @@ include(CTest)
 # add a custom SCIP check target 'scip_check'
 #
 add_custom_target(scip_check
-                COMMAND ${CMAKE_CTEST_COMMAND} -R "-default" -E "applications" --output-on-failure
+                COMMAND ${CMAKE_CTEST_COMMAND} -E "applications" --output-on-failure
                 DEPENDS scip
                 )
 


### PR DESCRIPTION
ctest doesn't like `-R "-default"`. CMake 4.0 fails with the following error message:

> CMake Error: Invalid value used with -R

`-R` normally specifies the regex that needs to match. If none is specified, all are selected:

https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-R

This maybe never worked, but got silently ignored until https://cmake.org/cmake/help/latest/policy/CMP0175.html

Removing that regex should only cause *more* tests to get selected, not less - and the build now succeeds with it.