### PR TITLE
Allow documentation builds when testing is turned off

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Fixed bugs
 ----------
 
 - disregard deletable flag in IIS generation to reenable removal of unused variables
+- fixed that doc target in cmake builds was not available when using DBUILD_TESTING=OFF
 
 @section RN1002 SCIP 10.0.2
 ***************************

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1022,7 +1022,6 @@ if(BUILD_TESTING)
     #
     add_custom_target(unittests)
     add_subdirectory(tests EXCLUDE_FROM_ALL)
-    add_subdirectory(doc EXCLUDE_FROM_ALL)
 
     #
     # add examples
@@ -1040,6 +1039,8 @@ if(BUILD_TESTING)
 
     add_custom_target(all_executables DEPENDS scip unittests examples applications)
 endif()
+
+add_subdirectory(doc EXCLUDE_FROM_ALL)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OLD_CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 


### PR DESCRIPTION
Currently, if we run cmake with `-DBUILD_TESTING=OFF`, then the resulting Makefile has no `doc` target.

This fixes Debian bug [#1131980](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1131980).