### PR TITLE
fix several typos

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1733,7 +1733,7 @@ Fixed bugs
 - read objective offset from ZIMPL files
 - Make sure that objective limit is disabled if not all variables are in the LP. If we would run into
   an objective limit in this case, the results of the LP solver are unclear.
-- fixed bug in reopt.c, which occured for bounds outside of current valid bounds
+- fixed bug in reopt.c, which occurred for bounds outside of current valid bounds
 - fixed problem with recomputing symmetries after a restart
 - fixed bug in SCIPcalcMIR() with wrong order of arguments for removeZerosQuad()
 - fixed segmentation fault in update of cut statistic
@@ -2883,7 +2883,7 @@ Features
 
 - Using the parameter "propagating/symmetry/recomputerestart" one can now decide to recompute symmetries after a
   restart or not. Previously one could just turn off symmetry computation after a restart. If orbital fixing
-  has found a reduction before the restart occured, symmetries have to be updated to ensure correctness.
+  has found a reduction before the restart occurred, symmetries have to be updated to ensure correctness.
   To this end, the user can decide via "propagating/symmetry/disableofrestart" whether orbital fixing is disabled or
    whether symmetries are recomputed.
 
@@ -2964,7 +2964,7 @@ Features
 - Expressions of form abs(x)^p * x in a nonlinear constraint are now sometimes recognized and handled by abspower constraints.
 
 - If polyhedral symmetry handling methods are used (cons_orbisack, cons_orbitope, cons_symresack), it is now possible to
-  recompute symmetries if a restart occured.
+  recompute symmetries if a restart occurred.
 
 - upgrade some more quadratic constraints to second-order cone constraints, that is,
   handle linear binary variables as if squared in simple upgrade and
@@ -3497,7 +3497,7 @@ Fixed bugs
 - fixed two issues related to (near-)redundant logicor constraints in presolving
 - fixed counting of aggregations in XOR constraint handler
 - fixed handling of unbounded solutions
-- fixed update of LP size information when an LP error occured during probing
+- fixed update of LP size information when an LP error occurred during probing
 - handle special case of variable bound constraints during aggregating variables
 - tighten sides of linear constraints before trying to upgrade them to more specialized constraints (knapsack, logic-or etc.) when calling SCIPupgradeConsLinear()
 - fixed an issue in repair heuristic in the case of loose (noncolumn) variables
@@ -6631,7 +6631,7 @@ Interface changes
   `constraints/setppc/cliqueshrinking`, first for enabling/disabling the clique lifting algorithm in cons_setppc.c,
   second parameter is for trying to create extra clique constraints in lifting algorithm, third parameter is for trying
   to decrease the number of variable in a clique constraint in the lifting algorithm
-- `limits/totalnodes` that allows to stop at the correct node if a restart occured; therefore the new
+- `limits/totalnodes` that allows to stop at the correct node if a restart occurred; therefore the new
   `SCIP_STATUS_TOTALNODELIMIT` is added
 - `lp/{rootiterlim,iterlim}` to set a limit on the LP iterations spend in the initial root LP and each
   LP resolve, respectively
@@ -7361,7 +7361,7 @@ Fixed bugs
   - fixed bug in debug.c: removed tree nodes had not been checked if they were pruned due to an incumbent solution found by a diving heuristic
 
 - Bounds:
-  - fixed bug which occured when changing a bound in the solving stage when this variables got upgraded from continuous to
+  - fixed bug which occurred when changing a bound in the solving stage when this variables got upgraded from continuous to
     a integer type, where the bounds of this variable were still not integral; due to that SCIPchgVarType() has changed (see above)
   - fixed bug in handling of lazy bounds that resulted in putting the bounds explicitly into the LP
 
@@ -7398,7 +7398,7 @@ Fixed bugs
   - fixed memory leak in coloring part of maximum clique algorithm (tclique_coloring.c) in a better way
 
 - Numerics:
-  - fixed bug which occured when the dual farkas multipliers were not available in the lpi because the LP could only be
+  - fixed bug which occurred when the dual farkas multipliers were not available in the lpi because the LP could only be
     solved with the primal simplex due to numerical problems
   - fixed bug in ZI round heuristic that led to infeasible shiftings for numerically slightly infeasible rows with close-to-zero coefficients
   - fixed numerical issue in octane heuristic: close-to-zero values for ray direction could have led to bad computations
@@ -7460,9 +7460,9 @@ Fixed bugs:
 - fixed bug in conflict.c, infeasibility analysis with big values led to wrong result
 
 - Heuristics:
-  - fixed bug in DINS heuristic that occured when the incumbent solution value is outside the variable's current domain
+  - fixed bug in DINS heuristic that occurred when the incumbent solution value is outside the variable's current domain
   - fixed behavior of LNS heuristics when the subproblem aborts: continue in optimized mode, stop in debug mode
-  - fixed segmentation fault in heur_subnlp.c which occured if resolving the NLP with a tighter feasibility tolerance
+  - fixed segmentation fault in heur_subnlp.c which occurred if resolving the NLP with a tighter feasibility tolerance
     failed with a solver error
   - fixed bug in heur_subnlp.c where constraints forbidding variable fixations where added if a cutoff was used in the subproblem
   - fixed bug in heur_subnlp.c where wrong constraints forbidding variable fixations where added in case of general integers
@@ -7603,7 +7603,7 @@ Features
   at the moment, it contains information about the relaxation solution stored in the variables: objective value and
   validness
 - SCIP may now be manually restarted
-- SCIPsolveKnapsackExactly() got a new 12. parameter `SCIP_Bool* success` which stores if an error occured during
+- SCIPsolveKnapsackExactly() got a new 12. parameter `SCIP_Bool* success` which stores if an error occurred during
   solving(normally a memory problem)
 - SCIP can now handle problems with continuous variables w.r.t. to counting (the projection to the integral variables
   are counted)
@@ -8419,7 +8419,7 @@ Fixed bugs
 - increased the numerical stability of coefficient tightening for Big M formulations
 - fixed bug with incorrect pseudo activities when objective of a variable switches sign in linear constraint handler
 - fixed bug with empty constraints in several writing routines
-- fixed `GGT-Kaibel-Bug` in var.c, prop_pseudoobj.c and cons_varbound.c that occured while computing new values using
+- fixed `GGT-Kaibel-Bug` in var.c, prop_pseudoobj.c and cons_varbound.c that occurred while computing new values using
   infinity values
 
 - Bounds:

--- a/applications/MinIISC/src/benders.h
+++ b/applications/MinIISC/src/benders.h
@@ -46,7 +46,7 @@ enum BENDERS_Status
    BENDERS_STATUS_SUCCESS          =  2,     /**< the solution is optimal, no further Benders cut has to be generated */
    BENDERS_STATUS_TIMELIMIT        =  3,     /**< the time limit has been reached */
    BENDERS_STATUS_USERINTERRUPT    =  4,     /**< the user has interrupted the solution of the subproblem */
-   BENDERS_STATUS_ERROR            =  5      /**< an error occured during the solution of the subproblem */
+   BENDERS_STATUS_ERROR            =  5      /**< an error occurred during the solution of the subproblem */
 };
 typedef enum BENDERS_Status BENDERS_STATUS;
 

--- a/applications/MinIISC/src/classify.c
+++ b/applications/MinIISC/src/classify.c
@@ -194,7 +194,7 @@ SCIP_RETCODE checkAltLPInfeasible(
    SCIP_LPI*             lp,                 /**< LP */
    SCIP_Bool             primal,             /**< whether we are using the primal or dual simplex */
    SCIP_Bool*            infeasible,         /**< output: whether the LP is infeasible */
-   SCIP_Bool*            error               /**< output: whether an error occured */
+   SCIP_Bool*            error               /**< output: whether an error occurred */
    )
 {
    SCIP_RETCODE retcode;

--- a/applications/MinIISC/src/miniisc.c
+++ b/applications/MinIISC/src/miniisc.c
@@ -191,7 +191,7 @@ SCIP_RETCODE checkAltLPInfeasible(
    SCIP_LPI*             lp,                 /**< LP */
    SCIP_Bool             primal,             /**< whether we are using the primal or dual simplex */
    SCIP_Bool*            infeasible,         /**< output: whether the LP is infeasible */
-   SCIP_Bool*            error               /**< output: whether an error occured */
+   SCIP_Bool*            error               /**< output: whether an error occurred */
    )
 {
    SCIP_RETCODE retcode;

--- a/applications/Scheduler/src/reader_sm.c
+++ b/applications/Scheduler/src/reader_sm.c
@@ -150,7 +150,7 @@ void parseError(
    SCIP*                 scip,               /**< SCIP data structure */
    int                   lineno,             /**< current line number of input file */
    const char*           msg,                /**< error message to display */
-   const char*           erritem,            /**< token where the error occured, or NULL */
+   const char*           erritem,            /**< token where the error occurred, or NULL */
    STATE*                state               /**< pointer to current reading state */
    )
 {

--- a/doc/xternal.c
+++ b/doc/xternal.c
@@ -8919,7 +8919,7 @@
  *       processed nodes or in the total number of simplex iterations.
  *  \arg <code>equal</code> - Solvers with instances whose number of processed nodes and total number of
  *       simplex iterations is equal to the reference solver (including a 10% tolerance) and where no timeout
- *       occured.
+ *       occurred.
  *  \arg <code>all optimal</code> - Solvers with instances that could be solved to optimality by
  *       <em>all</em> solvers; in particular, no timeout occurred.
  *

--- a/examples/Queens/doc/scip_intro.tex
+++ b/examples/Queens/doc/scip_intro.tex
@@ -89,7 +89,7 @@ if (retcode != SCIP_OKAY)
 }
 \end{verbatim}
 Since this is a lot of code for every function call, SCIP provides two macros namely \verb+SCIP_CALL+ and
-\verb+SCIP_CALL_ABORT+. The second one just aborts the execution by calling \verb+abort()+ if an error occured.
+\verb+SCIP_CALL_ABORT+. The second one just aborts the execution by calling \verb+abort()+ if an error occurred.
 The first one calls the SCIP function and, in the error case, returns the retcode. This results in the following code:
 \begin{verbatim}
 SCIP_RETCODE myfunction(void)

--- a/examples/Queens/doc/xternal_queens.c
+++ b/examples/Queens/doc/xternal_queens.c
@@ -97,7 +97,7 @@
  *
  * Since this is a lot of code for every function call, SCIP provides two
  * macros namely `SCIP_CALL` and `SCIP_CALL_ABORT`. The second one just
- * aborts the execution by calling `abort()` if an error occured. The first
+ * aborts the execution by calling `abort()` if an error occurred. The first
  * one calls the SCIP function and, in the error case, returns the retcode.
  * This results in the following code:
  *

--- a/examples/TSP/src/EventhdlrNewSol.cpp
+++ b/examples/TSP/src/EventhdlrNewSol.cpp
@@ -135,7 +135,7 @@ SCIP_DECL_EVENTDELETE(EventhdlrNewSol::scip_delete)
 /** execution method of event handler
  *
  *  Processes the event. The method is called every time an event occurs, for which the event handler
- *  is responsible. Event handlers may declare themselves resposible for events by calling the
+ *  is responsible. Event handlers may declare themselves responsible for events by calling the
  *  corresponding SCIPcatch...() method. This method creates an event filter object to point to the
  *  given event handler and event data.
  */

--- a/examples/TSP/src/EventhdlrNewSol.h
+++ b/examples/TSP/src/EventhdlrNewSol.h
@@ -84,7 +84,7 @@ public:
    /** execution method of event handler
     *
     *  Processes the event. The method is called every time an event occurs, for which the event handler
-    *  is responsible. Event handlers may declare themselves resposible for events by calling the
+    *  is responsible. Event handlers may declare themselves responsible for events by calling the
     *  corresponding SCIPcatch...() method. This method creates an event filter object to point to the
     *  given event handler and event data.
     */

--- a/src/lpi/lpi_spx.cpp
+++ b/src/lpi/lpi_spx.cpp
@@ -2652,7 +2652,7 @@ SCIP_RETCODE lpiStrongbranch(
          spx->restorePreStrongbranchingBasis();
          fromparentbasis = false;
 #else
-         /* if cycling or singular basis occured and we started not from the pre-strong-branching basis, then we restore the
+         /* if cycling or singular basis occurred and we started not from the pre-strong-branching basis, then we restore the
           * pre-strong-branching basis and try again with reduced iteration limit */
 #if SOPLEX_APIVERSION >= 3
          repeatstrongbranching = ((status == SPxSolver::ABORT_CYCLING || status == SPxSolver::OPTIMAL_UNSCALED_VIOLATIONS
@@ -2751,7 +2751,7 @@ SCIP_RETCODE lpiStrongbranch(
             spx->restorePreStrongbranchingBasis();
             fromparentbasis = false;
 #else
-            /* if cycling or singular basis occured and we started not from the pre-strong-branching basis, then we restore the
+            /* if cycling or singular basis occurred and we started not from the pre-strong-branching basis, then we restore the
              * pre-strong-branching basis and try again with reduced iteration limit */
 #if SOPLEX_APIVERSION >= 3
             repeatstrongbranching = ((status == SPxSolver::ABORT_CYCLING || status == SPxSolver::OPTIMAL_UNSCALED_VIOLATIONS

--- a/src/objscip/objbenders.h
+++ b/src/objscip/objbenders.h
@@ -287,7 +287,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyBenders* mybenders = new MyBenders(...);

--- a/src/objscip/objbranchrule.h
+++ b/src/objscip/objbranchrule.h
@@ -220,7 +220,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyBranchrule* mybranchrule = new MyBranchrule(...);

--- a/src/objscip/objconshdlr.h
+++ b/src/objscip/objconshdlr.h
@@ -511,7 +511,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyConshdlr* myconshdlr = new MyConshdlr(...);

--- a/src/objscip/objdialog.h
+++ b/src/objscip/objdialog.h
@@ -143,7 +143,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyDialog* mydialog = new MyDialog(...);

--- a/src/objscip/objdisp.h
+++ b/src/objscip/objdisp.h
@@ -204,7 +204,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyDisp* mydisp = new MyDisp(...);

--- a/src/objscip/objheur.h
+++ b/src/objscip/objheur.h
@@ -214,7 +214,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyHeur* myheur = new MyHeur(...);

--- a/src/objscip/objnodesel.h
+++ b/src/objscip/objnodesel.h
@@ -188,7 +188,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyNodesel* mynodesel = new MyNodesel(...);

--- a/src/objscip/objpresol.h
+++ b/src/objscip/objpresol.h
@@ -188,7 +188,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyPresol* mypresol = new MyPresol(...);

--- a/src/objscip/objpricer.h
+++ b/src/objscip/objpricer.h
@@ -190,7 +190,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyPricer* mypricer = new MyPricer(...);

--- a/src/objscip/objprobdata.h
+++ b/src/objscip/objprobdata.h
@@ -198,7 +198,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyProbData* myprobdata = new MyProbData(...);

--- a/src/objscip/objprop.h
+++ b/src/objscip/objprop.h
@@ -257,7 +257,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyProp* myprop = new MyProp(...);

--- a/src/objscip/objreader.h
+++ b/src/objscip/objreader.h
@@ -159,7 +159,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyReader* myreader = new MyReader(...);

--- a/src/objscip/objrelax.h
+++ b/src/objscip/objrelax.h
@@ -187,7 +187,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyRelax* myrelax = new MyRelax(...);

--- a/src/objscip/objsepa.h
+++ b/src/objscip/objsepa.h
@@ -219,7 +219,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MySepa* mysepa = new MySepa(...);

--- a/src/objscip/objtable.h
+++ b/src/objscip/objtable.h
@@ -190,7 +190,7 @@ public:
  *
  *  The method should be called in one of the following ways:
  *
- *   1. The user is resposible of deleting the object:
+ *   1. The user is responsible of deleting the object:
  *       SCIP_CALL( SCIPcreate(&scip) );
  *       ...
  *       MyTable* mytable = new MyTable(...);

--- a/src/scip/branch_lookahead.c
+++ b/src/scip/branch_lookahead.c
@@ -1139,7 +1139,7 @@ typedef struct
    int                   nsingleafterfilter; /**< number of times a single candidate remained after filtering */
    int                   noldcandidate;      /**< number of times the old candidate from last call with nonviolating
                                               *   reductions was branched on */
-   int                   nlperrorcalls;      /**< number of times an LP error occured and LAB branched without completely
+   int                   nlperrorcalls;      /**< number of times an LP error occurred and LAB branched without completely
                                               *   evaluating all candidates */
    int                   nlimitcalls;        /**< number of times a time limit was reached and LAB branched without
                                               *   completely evaluating all candidates */

--- a/src/scip/cons_knapsack.c
+++ b/src/scip/cons_knapsack.c
@@ -1100,7 +1100,7 @@ SCIP_RETCODE SCIPsolveKnapsackExactly(
    int*                  nsolitems,          /**< pointer to store number of items in solution, or NULL */
    int*                  nnonsolitems,       /**< pointer to store number of items not in solution, or NULL */
    SCIP_Real*            solval,             /**< pointer to store optimal solution value, or NULL */
-   SCIP_Bool*            success             /**< pointer to store if an error occured during solving
+   SCIP_Bool*            success             /**< pointer to store if an error occurred during solving
                                               *   (normally a memory problem) */
    )
 {

--- a/src/scip/cons_knapsack.h
+++ b/src/scip/cons_knapsack.h
@@ -231,7 +231,7 @@ SCIP_RETCODE SCIPsolveKnapsackExactly(
    int*                  nsolitems,          /**< pointer to store number of items in solution, or NULL */
    int*                  nnonsolitems,       /**< pointer to store number of items not in solution, or NULL */
    SCIP_Real*            solval,             /**< pointer to store optimal solution value, or NULL */
-   SCIP_Bool*            success             /**< pointer to store if an error occured during solving
+   SCIP_Bool*            success             /**< pointer to store if an error occurred during solving
                                               *   (normally a memory problem) */
    );
 

--- a/src/scip/exprinterpret_cppad.cpp
+++ b/src/scip/exprinterpret_cppad.cpp
@@ -1461,8 +1461,8 @@ SCIP_RETCODE eval(
 static
 void cppaderrorcallback(
    bool                  known,              /**< is the error from a known source? */
-   int                   line,               /**< line where error occured */
-   const char*           file,               /**< file where error occured */
+   int                   line,               /**< line where error occurred */
+   const char*           file,               /**< file where error occurred */
    const char*           cond,               /**< error condition */
    const char*           msg                 /**< error message */
    )

--- a/src/scip/fileio.c
+++ b/src/scip/fileio.c
@@ -58,7 +58,7 @@ size_t SCIPfread(void *ptr, size_t size, size_t nmemb, SCIP_FILE *stream)
    int nbytesread;
 
    nbytesread = gzread((gzFile)stream, ptr, (unsigned int) (size * nmemb));
-   /* An error occured if nbytesread < 0. To be compatible with fread(), we return 0, which signifies an error there. */
+   /* An error occurred if nbytesread < 0. To be compatible with fread(), we return 0, which signifies an error there. */
    if ( nbytesread < 0 )
       return 0;
 

--- a/src/scip/heur_intdiving.c
+++ b/src/scip/heur_intdiving.c
@@ -532,7 +532,7 @@ SCIP_DECL_HEUREXEC(heurExecIntdiving) /*lint --e{715}*/
       do
       {
          /* if the variable is already fixed or if the solution value is outside the domain, numerical troubles may have
-          * occured or variable was fixed by propagation while backtracking => Abort diving!
+          * occurred or variable was fixed by propagation while backtracking => Abort diving!
           */
          if( SCIPvarGetLbLocal(var) >= SCIPvarGetUbLocal(var) - 0.5 )
          {

--- a/src/scip/heur_mpec.c
+++ b/src/scip/heur_mpec.c
@@ -385,7 +385,7 @@ SCIP_RETCODE heurExec(
       /* give up if an error occurred or no primal values are accessible */
       if( solstat > SCIP_NLPSOLSTAT_LOCINFEASIBLE )
       {
-         SCIPdebugMsg(scip, "error occured during NLP solve -> stop!\n");
+         SCIPdebugMsg(scip, "error occurred during NLP solve -> stop!\n");
          break;
       }
 

--- a/src/scip/heur_nlpdiving.c
+++ b/src/scip/heur_nlpdiving.c
@@ -2173,7 +2173,7 @@ SCIP_DECL_HEUREXEC(heurExecNlpdiving)
             assert(backtrackvar != NULL);
 
             /* if the variable is already fixed or if the solution value is outside the domain, numerical troubles may have
-             * occured or variable was fixed by propagation while backtracking => Abort diving!
+             * occurred or variable was fixed by propagation while backtracking => Abort diving!
              */
             if( SCIPvarGetLbLocal(backtrackvar) >= SCIPvarGetUbLocal(backtrackvar) - 0.5 )
             {
@@ -2221,7 +2221,7 @@ SCIP_DECL_HEUREXEC(heurExecNlpdiving)
             assert(var != NULL);
 
             /* if the variable is already fixed or if the solution value is outside the domain, numerical troubles may have
-             * occured or variable was fixed by propagation while backtracking => Abort diving!
+             * occurred or variable was fixed by propagation while backtracking => Abort diving!
              */
             if( SCIPvarGetLbLocal(var) >= SCIPvarGetUbLocal(var) - 0.5 )
             {

--- a/src/scip/heur_shiftandpropagate.c
+++ b/src/scip/heur_shiftandpropagate.c
@@ -2001,7 +2001,7 @@ SCIP_DECL_HEUREXEC(heurExecShiftandpropagate)
 
          ++ncutoffs;
 
-         /* only continue heuristic if number of cutoffs occured so far is reasonably small */
+         /* only continue heuristic if number of cutoffs occurred so far is reasonably small */
          if( heurdata->cutoffbreaker >= 0 && ncutoffs >= ((heurdata->maxcutoffquot * SCIPgetProbingDepth(scip)) + heurdata->cutoffbreaker) )
             break;
 

--- a/src/scip/heur_twoopt.c
+++ b/src/scip/heur_twoopt.c
@@ -81,7 +81,7 @@
 struct SCIP_HeurData
 {
    int                   lastsolindex;       /**< index of last solution for which heuristic was performed */
-   SCIP_Real             matchingrate;       /**< percentage by which two variables have have to match in their LP-row
+   SCIP_Real             matchingrate;       /**< percentage by which two variables have to match in their LP-row
                                               *   set to be associated as pair by heuristic */
    SCIP_VAR**            binvars;            /**< Array of binary variables which are sorted with respect to their occurrence
                                               *   in the LP-rows */

--- a/src/scip/heuristics.c
+++ b/src/scip/heuristics.c
@@ -690,7 +690,7 @@ SCIP_RETCODE SCIPperformGenericDivingAlgorithm(
                      return SCIP_INVALIDDATA; /*lint !e527*/
                }
                /* if the variable domain has been shrunk in the meantime, numerical troubles may have
-                * occured or variable was fixed by propagation while backtracking => Abort diving!
+                * occurred or variable was fixed by propagation while backtracking => Abort diving!
                 */
                if( infeasbdchange )
                {

--- a/src/scip/message.h
+++ b/src/scip/message.h
@@ -30,15 +30,15 @@
  * Because the message functions are implemented as defines with more than one
  * function call, they shouldn't be used as a single statement like in:
  *   if( error )
- *      SCIPerrorMessage("an error occured");
+ *      SCIPerrorMessage("an error occurred");
  * because this would produce the following macro extension:
  *   if( error )
  *      printf(("[%s:%d] ERROR: ", __FILE__, __LINE__);
- *   printf(("an error occured");
+ *   printf(("an error occurred");
  * Instead, they should be protected with brackets:
  *   if( error )
  *   {
- *      SCIPerrorMessage("an error occured");
+ *      SCIPerrorMessage("an error occurred");
  *   }
  */
 

--- a/src/scip/prop_obbt.c
+++ b/src/scip/prop_obbt.c
@@ -297,7 +297,7 @@ SCIP_RETCODE solveLP(
          SCIPdebugMsg(scip, "   lp was not solved\n");
          break;
       case SCIP_LPSOLSTAT_ERROR:
-         SCIPdebugMsg(scip, "   an error occured during solving lp\n");
+         SCIPdebugMsg(scip, "   an error occurred during solving lp\n");
          break;
       case SCIP_LPSOLSTAT_INFEASIBLE:
       case SCIP_LPSOLSTAT_OBJLIMIT:
@@ -1768,7 +1768,7 @@ SCIP_RETCODE applySeparation(
       SCIPdebug( SCIPdebugMsg(scip, "applySeparation() - optimal=%u error=%u lpiter=%" SCIP_LONGINT_FORMAT "\n", optimal, error, nlpiter); )
       SCIPdebugMsg(scip, "oldval = %e newval = %e\n", oldval, SCIPvarGetLPSol(currbound->var));
 
-      /* leave if we did not solve the LP to optimality or an error occured */
+      /* leave if we did not solve the LP to optimality or an error occurred */
       if( error || !optimal )
          break;
 
@@ -3185,7 +3185,7 @@ SCIP_DECL_PROPEXEC(propExecObbt)
    SCIPdebugMsg(scip, "applying obbt for problem <%s> at depth %d\n", SCIPgetProbName(scip), SCIPgetDepth(scip));
 
    /* without an optimal LP solution we don't want to run; this may be because propagators with higher priority have
-    * already found reductions or numerical troubles occured during LP solving
+    * already found reductions or numerical troubles occurred during LP solving
     */
    if( SCIPgetLPSolstat(scip) != SCIP_LPSOLSTAT_OPTIMAL && SCIPgetLPSolstat(scip) != SCIP_LPSOLSTAT_UNBOUNDEDRAY )
    {

--- a/src/scip/prop_probing.c
+++ b/src/scip/prop_probing.c
@@ -353,7 +353,7 @@ SCIP_RETCODE applyProbing(
    int                   oldnfixedvars,      /**< number of previously fixed variables */
    int                   oldnaggrvars,       /**< number of previously aggregated variables */
    SCIP_Bool*            delay,              /**< pointer to store whether propagator should be delayed */
-   SCIP_Bool*            cutoff              /**< pointer to store whether cutoff occured */
+   SCIP_Bool*            cutoff              /**< pointer to store whether cutoff occurred */
    )
 {
    SCIP_Real* zeroimpllbs;

--- a/src/scip/scip_dcmp.c
+++ b/src/scip/scip_dcmp.c
@@ -440,7 +440,7 @@ SCIP_RETCODE SCIPcomputeDecompConsLabels(
 /** creates a decomposition of the variables from a labeling of the constraints
  *
  *  NOTE: by default, the variable labeling is based on a Dantzig-Wolfe decomposition. This means that constraints in named
- *  blocks have have precedence over linking constraints. If a variable exists in constraints from
+ *  blocks have precedence over linking constraints. If a variable exists in constraints from
  *  two or more named blocks, then this variable is marked as a linking variable.
  *  If a variable occurs in exactly one named block i>=0, it is assigned label i.
  *  Variables which are only in linking constraints are unlabeled. However, SCIPdecompGetVarsLabels() will

--- a/src/scip/scip_dcmp.h
+++ b/src/scip/scip_dcmp.h
@@ -115,7 +115,7 @@ SCIP_RETCODE SCIPcomputeDecompConsLabels(
 /** creates a decomposition of the variables from a labeling of the constraints
  *
  *  NOTE: by default, the variable labeling is based on a Dantzig-Wolfe decomposition. This means that constraints in named
- *  blocks have have precedence over linking constraints. If a variable exists in constraints from
+ *  blocks have precedence over linking constraints. If a variable exists in constraints from
  *  two or more named blocks, then this variable is marked as a linking variable.
  *  If a variable occurs in exactly one named block i>=0, it is assigned label i.
  *  Variables which are only in linking constraints are unlabeled. However, SCIPdecompGetVarsLabels() will

--- a/src/scip/scip_lp.c
+++ b/src/scip/scip_lp.c
@@ -1158,7 +1158,7 @@ SCIP_RETCODE SCIPcomputeLPRelIntPoint(
  *  @note calling this method in SCIP_STAGE_SOLVED is only recommended to experienced users and should only be called
  *        for pure LP instances (without presolving)
  *
- *  @note The return value of this method should be used carefully if the dual feasibility check was explictely disabled.
+ *  @note The return value of this method should be used carefully if the dual feasibility check was explicitly disabled.
  */
 SCIP_Real SCIPgetColRedcost(
    SCIP*                 scip,               /**< SCIP data structure */

--- a/src/scip/scip_lp.h
+++ b/src/scip/scip_lp.h
@@ -776,7 +776,7 @@ SCIP_RETCODE SCIPcomputeLPRelIntPoint(
  *  @note calling this method in SCIP_STAGE_SOLVED is only recommended to experienced users and should only be called
  *        for pure LP instances (without presolving)
  *
- *  @note The return value of this method should be used carefully if the dual feasibility check was explictely disabled.
+ *  @note The return value of this method should be used carefully if the dual feasibility check was explicitly disabled.
  */
 SCIP_EXPORT
 SCIP_Real SCIPgetColRedcost(

--- a/src/scip/scip_sol.c
+++ b/src/scip/scip_sol.c
@@ -3328,7 +3328,7 @@ SCIP_RETCODE readSolFile(
    const char*           filename,           /**< name of the input file */
    SCIP_SOL*             sol,                /**< solution pointer */
    SCIP_Bool*            partial,            /**< pointer to store if the solution is partial (or NULL, if not needed) */
-   SCIP_Bool*            error               /**< pointer store if an error occured */
+   SCIP_Bool*            error               /**< pointer store if an error occurred */
    )
 {
    SCIP_HASHSET* unknownvars = NULL;
@@ -3562,7 +3562,7 @@ SCIP_RETCODE readXmlSolFile(
    const char*           filename,           /**< name of the input file */
    SCIP_SOL*             sol,                /**< solution pointer */
    SCIP_Bool*            partial,            /**< pointer to store if the solution is partial (or NULL if not needed) */
-   SCIP_Bool*            error               /**< pointer store if an error occured */
+   SCIP_Bool*            error               /**< pointer store if an error occurred */
    )
 {
    SCIP_HASHSET* unknownvars = NULL;
@@ -3583,7 +3583,7 @@ SCIP_RETCODE readXmlSolFile(
 
    if( start == NULL )
    {
-      SCIPerrorMessage("Some error occured during parsing the XML solution file.\n");
+      SCIPerrorMessage("Some error occurred during parsing the XML solution file.\n");
       return SCIP_READERROR;
    }
 
@@ -3810,7 +3810,7 @@ SCIP_RETCODE SCIPreadSolFile(
    SCIP_SOL*             sol,                /**< solution pointer */
    SCIP_Bool             xml,                /**< true, iff the given solution in written in XML */
    SCIP_Bool*            partial,            /**< pointer to store if the solution is partial */
-   SCIP_Bool*            error               /**< pointer store if an error occured */
+   SCIP_Bool*            error               /**< pointer store if an error occurred */
    )
 {
    SCIP_CALL( SCIPcheckStage(scip, "SCIPreadSolFile", FALSE, TRUE, FALSE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE) );

--- a/src/scip/scip_sol.h
+++ b/src/scip/scip_sol.h
@@ -1385,7 +1385,7 @@ SCIP_RETCODE SCIPreadSolFile(
    SCIP_SOL*             sol,                /**< solution pointer */
    SCIP_Bool             xml,                /**< true, iff the given solution in written in XML */
    SCIP_Bool*            partial,            /**< pointer to store if the solution is partial */
-   SCIP_Bool*            error               /**< pointer store if an error occured */
+   SCIP_Bool*            error               /**< pointer store if an error occurred */
    );
 
 /** adds feasible primal solution to solution storage by copying it

--- a/src/scip/scip_var.c
+++ b/src/scip/scip_var.c
@@ -1118,7 +1118,7 @@ SCIP_RETCODE SCIPparseVarsPolynomial(
       SCIPPARSEPOLYNOMIAL_STATE_VARS,        /* we parse monomial variables */
       SCIPPARSEPOLYNOMIAL_STATE_EXPONENT,    /* we parse the exponent of a variable */
       SCIPPARSEPOLYNOMIAL_STATE_END,         /* we are at the end the polynomial */
-      SCIPPARSEPOLYNOMIAL_STATE_ERROR        /* a parsing error occured */
+      SCIPPARSEPOLYNOMIAL_STATE_ERROR        /* a parsing error occurred */
    } SCIPPARSEPOLYNOMIAL_STATES;
 
    SCIPPARSEPOLYNOMIAL_STATES state;
@@ -1469,7 +1469,7 @@ SCIP_RETCODE SCIPparseVarsPolynomialExact(
       SCIPPARSEPOLYNOMIAL_STATE_VARS,        /* we parse monomial variables */
       SCIPPARSEPOLYNOMIAL_STATE_EXPONENT,    /* we parse the exponent of a variable */
       SCIPPARSEPOLYNOMIAL_STATE_END,         /* we are at the end the polynomial */
-      SCIPPARSEPOLYNOMIAL_STATE_ERROR        /* a parsing error occured */
+      SCIPPARSEPOLYNOMIAL_STATE_ERROR        /* a parsing error occurred */
    } SCIPPARSEPOLYNOMIAL_STATES;
 
    SCIPPARSEPOLYNOMIAL_STATES state;
@@ -2604,7 +2604,7 @@ SCIP_RETCODE SCIPgetActiveVars(
  *
  *  @pre This method can only be called if @p scip is in stage \ref SCIP_STAGE_SOLVING
  *
- *  @note The return value of this method should be used carefully if the dual feasibility check was explictely disabled.
+ *  @note The return value of this method should be used carefully if the dual feasibility check was explicitly disabled.
  */
 SCIP_Real SCIPgetVarRedcost(
    SCIP*                 scip,               /**< SCIP data structure */
@@ -2649,7 +2649,7 @@ SCIP_Real SCIPgetVarRedcost(
  *
  *  @pre This method can only be called if @p scip is in stage \ref SCIP_STAGE_SOLVING
  *
- *  @note The return value of this method should be used carefully if the dual feasibility check was explictely disabled.
+ *  @note The return value of this method should be used carefully if the dual feasibility check was explicitly disabled.
  */
 SCIP_Real SCIPgetVarImplRedcost(
    SCIP*                 scip,               /**< SCIP data structure */

--- a/src/scip/scip_var.h
+++ b/src/scip/scip_var.h
@@ -1074,7 +1074,7 @@ SCIP_RETCODE SCIPgetActiveVars(
  *
  *  @pre This method can only be called if @p scip is in stage \ref SCIP_STAGE_SOLVING
  *
- *  @note The return value of this method should be used carefully if the dual feasibility check was explictely disabled.
+ *  @note The return value of this method should be used carefully if the dual feasibility check was explicitly disabled.
  */
 SCIP_EXPORT
 SCIP_Real SCIPgetVarRedcost(
@@ -1090,7 +1090,7 @@ SCIP_Real SCIPgetVarRedcost(
  *
  *  @pre This method can only be called if @p scip is in stage \ref SCIP_STAGE_SOLVING
  *
- *  @note The return value of this method should be used carefully if the dual feasibility check was explictely disabled.
+ *  @note The return value of this method should be used carefully if the dual feasibility check was explicitly disabled.
  */
 SCIP_EXPORT
 SCIP_Real SCIPgetVarImplRedcost(

--- a/src/scip/solve.c
+++ b/src/scip/solve.c
@@ -2556,7 +2556,7 @@ SCIP_RETCODE solveNodeInitialLP(
    SCIP_Bool             newinitconss,       /**< do we have to add new initial constraints? */
    SCIP_Bool             forcedlpsolve,      /**< would SCIP abort if the LP is not solved? */
    SCIP_Bool*            cutoff,             /**< pointer to store whether the node can be cut off */
-   SCIP_Bool*            lperror             /**< pointer to store whether an unresolved error in LP solving occured */
+   SCIP_Bool*            lperror             /**< pointer to store whether an unresolved error in LP solving occurred */
    )
 {
    /* initializing variables for compiler warnings, which are not correct */
@@ -2663,7 +2663,7 @@ SCIP_RETCODE separationRoundResolveLP(
    SCIP_PRIMAL*          primal,             /**< primal data */
    SCIP_TREE*            tree,               /**< branch and bound tree */
    SCIP_LP*              lp,                 /**< LP data */
-   SCIP_Bool*            lperror,            /**< pointer to store whether an unresolved error in LP solving occured */
+   SCIP_Bool*            lperror,            /**< pointer to store whether an unresolved error in LP solving occurred */
    SCIP_Bool*            mustsepa,           /**< pointer to store TRUE if additional separation rounds should be performed */
    SCIP_Bool*            mustprice           /**< pointer to store TRUE if additional pricing rounds should be performed */
    )
@@ -2712,7 +2712,7 @@ SCIP_RETCODE separationRoundLP(
    SCIP_Bool*            delayed,            /**< pointer to store whether a separator was delayed */
    SCIP_Bool*            enoughcuts,         /**< pointer to store whether enough cuts have been found this round */
    SCIP_Bool*            cutoff,             /**< pointer to store whether the node can be cut off */
-   SCIP_Bool*            lperror,            /**< pointer to store whether an unresolved error in LP solving occured */
+   SCIP_Bool*            lperror,            /**< pointer to store whether an unresolved error in LP solving occurred */
    SCIP_Bool*            mustsepa,           /**< pointer to store TRUE if additional separation rounds should be performed */
    SCIP_Bool*            mustprice           /**< pointer to store TRUE if additional pricing rounds should be performed */
    )
@@ -3426,7 +3426,7 @@ SCIP_RETCODE SCIPpriceLoop(
                                               *   a finite limit means that the LP might not be solved to optimality! */
    int*                  npricedcolvars,     /**< pointer to store number of column variables after problem vars were priced */
    SCIP_Bool*            mustsepa,           /**< pointer to store TRUE if a separation round should follow */
-   SCIP_Bool*            lperror,            /**< pointer to store whether an unresolved error in LP solving occured */
+   SCIP_Bool*            lperror,            /**< pointer to store whether an unresolved error in LP solving occurred */
    SCIP_Bool*            aborted             /**< pointer to store whether the pricing was aborted and the lower bound must
                                               *   not be used */
    )
@@ -3704,7 +3704,7 @@ SCIP_RETCODE priceAndCutLoop(
    SCIP_Bool*            propagateagain,     /**< pointer to store whether we want to propagate again */
    SCIP_Bool*            cutoff,             /**< pointer to store whether the node can be cut off */
    SCIP_Bool*            unbounded,          /**< pointer to store whether an unbounded ray was found in the LP */
-   SCIP_Bool*            lperror,            /**< pointer to store whether an unresolved error in LP solving occured */
+   SCIP_Bool*            lperror,            /**< pointer to store whether an unresolved error in LP solving occurred */
    SCIP_Bool*            pricingaborted      /**< pointer to store whether the pricing was aborted and the lower bound must
                                               *   not be used */
    )
@@ -4422,7 +4422,7 @@ SCIP_RETCODE solveNodeLP(
    SCIP_Bool*            solverelaxagain,    /**< pointer to store TRUE, if the external relaxators should be called again */
    SCIP_Bool*            cutoff,             /**< pointer to store TRUE, if the node can be cut off */
    SCIP_Bool*            unbounded,          /**< pointer to store TRUE, if an unbounded ray was found in the LP */
-   SCIP_Bool*            lperror,            /**< pointer to store TRUE, if an unresolved error in LP solving occured */
+   SCIP_Bool*            lperror,            /**< pointer to store TRUE, if an unresolved error in LP solving occurred */
    SCIP_Bool*            pricingaborted      /**< pointer to store TRUE, if the pricing was aborted and the lower bound
                                               *   must not be used */
    )
@@ -5185,7 +5185,7 @@ SCIP_RETCODE propAndSolve(
    SCIP_Bool*            postpone,           /**< pointer to store whether the node should be postponed */
    SCIP_Bool*            unbounded,          /**< pointer to store whether the focus node is unbounded */
    SCIP_Bool*            stopped,            /**< pointer to store whether solving was interrupted */
-   SCIP_Bool*            lperror,            /**< pointer to store TRUE, if an unresolved error in LP solving occured */
+   SCIP_Bool*            lperror,            /**< pointer to store TRUE, if an unresolved error in LP solving occurred */
    SCIP_Bool*            pricingaborted,     /**< pointer to store TRUE, if the pricing was aborted and the lower bound must not be used */
    SCIP_Bool*            forcedenforcement   /**< pointer to store whether the enforcement of pseudo solution should be forced */
    )
@@ -5402,7 +5402,7 @@ SCIP_RETCODE propAndSolve(
       /* check, if the path was cutoff */
       *cutoff = *cutoff || (tree->cutoffdepth <= actdepth);
 
-      /* if an error occured during LP solving, switch to pseudo solution */
+      /* if an error occurred during LP solving, switch to pseudo solution */
       if( *lperror )
       {
          if( forcedlpsolve )

--- a/src/scip/solve.h
+++ b/src/scip/solve.h
@@ -222,7 +222,7 @@ SCIP_RETCODE SCIPpriceLoop(
                                               *   a finite limit means that the LP might not be solved to optimality! */
    int*                  npricedcolvars,     /**< pointer to store number of column variables after problem vars were priced */
    SCIP_Bool*            mustsepa,           /**< pointer to store TRUE if a separation round should follow */
-   SCIP_Bool*            lperror,            /**< pointer to store whether an unresolved error in LP solving occured */
+   SCIP_Bool*            lperror,            /**< pointer to store whether an unresolved error in LP solving occurred */
    SCIP_Bool*            aborted             /**< pointer to store whether the pricing was aborted and the lower bound must
                                               *   not be used */
    );

--- a/src/scip/struct_lpexact.h
+++ b/src/scip/struct_lpexact.h
@@ -333,7 +333,7 @@ struct SCIP_LpExact
    SCIP_Bool             dualfeasible;       /**< is current LP solution (rather LPI state) dual feasible? */
    SCIP_Bool             dualchecked;        /**< was current LP solution checked for primal feasibility?? */
    SCIP_Bool             solisbasic;         /**< is current LP solution a basic solution? */
-   SCIP_Bool             resolvelperror;     /**< an error occured during resolving the LP after diving or probing */
+   SCIP_Bool             resolvelperror;     /**< an error occurred during resolving the LP after diving or probing */
    SCIP_Bool             lpihasscaling;      /**< does the LPI support the SCALING parameter? */
    SCIP_Bool             lpihaspresolving;   /**< does the LPI support the PRESOLVING parameter? */
    SCIP_Bool             projshiftpossible;  /**< can a safe bound be computed with project-and-shift? */

--- a/src/scip/tree.c
+++ b/src/scip/tree.c
@@ -4741,7 +4741,7 @@ SCIP_RETCODE focusnodeToFork(
    SCIPsetDebugMsg(set, "focusnode #%" SCIP_LONGINT_FORMAT " to fork at depth %d\n",
       SCIPnodeGetNumber(tree->focusnode), SCIPnodeGetDepth(tree->focusnode));
 
-   /* usually, the LP should be solved to optimality; otherwise, numerical troubles occured,
+   /* usually, the LP should be solved to optimality; otherwise, numerical troubles occurred,
     * and we have to forget about the LP and transform the node into a junction (see below)
     */
    lperror = FALSE;
@@ -4853,7 +4853,7 @@ SCIP_RETCODE focusnodeToSubroot(
    SCIPsetDebugMsg(set, "focusnode #%" SCIP_LONGINT_FORMAT " to subroot at depth %d\n",
       SCIPnodeGetNumber(tree->focusnode), SCIPnodeGetDepth(tree->focusnode));
 
-   /* usually, the LP should be solved to optimality; otherwise, numerical troubles occured,
+   /* usually, the LP should be solved to optimality; otherwise, numerical troubles occurred,
     * and we have to forget about the LP and transform the node into a junction (see below)
     */
    lperror = FALSE;
@@ -7991,7 +7991,7 @@ SCIP_RETCODE SCIPtreeEndProbing(
    /* if no LP was solved during probing and the LP before probing was not solved, then it should not be solved now */
    assert(tree->probingsolvedlp || tree->probinglpwassolved || !lp->solved);
 
-   /* if the LP was solved (and hence flushed) before probing, then lp->solved should be TRUE unless we occured an error
+   /* if the LP was solved (and hence flushed) before probing, then lp->solved should be TRUE unless we occurred an error
     * during resolving right above
     */
    assert(!tree->probinglpwassolved || !tree->probinglpwasflushed || lp->solved || lp->resolvelperror);

--- a/src/scip/type_lp.h
+++ b/src/scip/type_lp.h
@@ -47,7 +47,7 @@ enum SCIP_LPSolStat
    SCIP_LPSOLSTAT_OBJLIMIT     = 4,     /**< objective limit was reached during optimization */
    SCIP_LPSOLSTAT_ITERLIMIT    = 5,     /**< iteration limit was reached during optimization */
    SCIP_LPSOLSTAT_TIMELIMIT    = 6,     /**< time limit was reached during optimization */
-   SCIP_LPSOLSTAT_ERROR        = 7      /**< an error occured during optimization */
+   SCIP_LPSOLSTAT_ERROR        = 7      /**< an error occurred during optimization */
 };
 typedef enum SCIP_LPSolStat SCIP_LPSOLSTAT;
 

--- a/src/scip/var.c
+++ b/src/scip/var.c
@@ -3000,7 +3000,7 @@ SCIP_RETCODE parseBounds(
    SCIP_Real*            ub,                 /**< pointer to store the upper bound */
    SCIP_RATIONAL*        lbexact,            /**< pointer to store the exact lower bound */
    SCIP_RATIONAL*        ubexact,            /**< pointer to store the exact upper bound */
-   char**                endptr              /**< pointer to store the final string position if successfully parsed (or NULL if an error occured) */
+   char**                endptr              /**< pointer to store the final string position if successfully parsed (or NULL if an error occurred) */
    )
 {
    char token[SCIP_MAXSTRLEN];

--- a/src/tclique/tclique_graph.c
+++ b/src/tclique/tclique_graph.c
@@ -634,7 +634,7 @@ TCLIQUE_Bool tcliqueLoadFile(
    }
 
    /* set data structures for tclique,
-    * if an error occured, close the file before returning */
+    * if an error occurred, close the file before returning */
    /* coverity[tainted_data] */
    if( BMSallocMemoryArray(&(*tcliquegraph)->weights, (*tcliquegraph)->nnodes) == NULL )
    {


### PR DESCRIPTION
I stumbled over one 'occu*r*ed' and did a text search through our C/C++ code base. This pull request fixes all occurrences within SCIP.
It's also in Soplex and highs, lemon, coin-or osi and some boost 1.88 libraries... 

Contains a few other typos.