### PR TITLE
[docs] Add Conan entry in installation documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -629,6 +629,26 @@ If your platform or compiler is not supported by SCIP you might try and copy one
 makefiles in the `make` directory and modify it. If you succeed, we are always
 interested in including more Makefiles into the system.
 
+Installing SCIP using dependency management tools
+=================================================
+
+If you are using a dependency management tool, you can also install SCIP using the respective package manager,
+instead of compiling it from source code.
+
+Conan
+-----
+
+You can download and install SCIP using the [Conan](https://conan.io/) dependency manager:
+
+```
+conan install -r conancenter --requires="scip/[*]" --build=missing
+```
+
+The SCIP package in Conan Center is maintained by
+[ConanCenterIndex](https://github.com/conan-io/conan-center-index) community.
+If the version is out of date or the package does not work,
+please create an issue or pull request on the [Conan Center Index repository](https://github.com/conan-io/conan-center-index).
+
 Examples
 --------
 


### PR DESCRIPTION
Greetings!

As you may know, the SCIP project has been available on the Conan Center for a considerable period: https://conan.io/center/recipes/scip?version=10.0.2

Most recently, we discussed Conan involvement in PR #200 

I opened this new PR to provide a chance for users to learn how to install SCIP using Conan. So, avoiding all the manual build steps.

The pattern scip/[*] indicates "the latest version available".

Please, let me know if it's okay, or if I should move it to another place. Regards!