### PR TITLE
Fix typo in MSVC version number

### DIFF
--- a/src/amplmp/include/mp/format.h
+++ b/src/amplmp/include/mp/format.h
@@ -41,7 +41,7 @@
 #include <utility>
 
 // std::unchecked_array_iterator removed for C++ >= 17 with MSVC 2026
-#if defined(_SECURE_SCL) && (!defined(_MSC_VER) || _MSC_VER < 1915)
+#if defined(_SECURE_SCL) && (!defined(_MSC_VER) || _MSC_VER < 1951)
 # define FMT_SECURE_SCL _SECURE_SCL
 #else
 # define FMT_SECURE_SCL 0


### PR DESCRIPTION
My initial proposal 07818c722d5c016d22b756dac949471b3a44b344 contained a typo. version number has to be 1951, not 1915