### PR TITLE
check primal bound only if optimal solution found

### DIFF
--- a/examples/LennardJones/check/CMakeLists.txt
+++ b/examples/LennardJones/check/CMakeLists.txt
@@ -35,7 +35,7 @@ foreach(instance ${instances})
             )
     set_tests_properties("examples-lj-${nparticles}"
                          PROPERTIES
-                            PASS_REGULAR_EXPRESSION "(optimal solution found|gap limit reached).*Primal Bound *: ${optval}\\.0000.*e\\+00"
+                            PASS_REGULAR_EXPRESSION "(optimal solution found.*Primal Bound *: ${optval}\\.0000.*e\\+00|gap limit reached)"
                             FAIL_REGULAR_EXPRESSION "ERROR"
                             DEPENDS examples-lj-build
                             RESOURCE_LOCK libscip


### PR DESCRIPTION
If gap limit is reached, one may have stopped with a suboptimal solution.

Tries to fix https://github.com/scipopt/scip/actions/runs/34058044917/job/101553439934.